### PR TITLE
fix: remove group_size=1 override that disabled G normalization in PUCT

### DIFF
--- a/tinker_cookbook/recipes/ttt/sampler.py
+++ b/tinker_cookbook/recipes/ttt/sampler.py
@@ -352,8 +352,6 @@ class PUCTSampler(StateSampler):
         self.topk_children = topk_children
         self.puct_c = float(puct_c)
         self.group_size = int(group_size)
-        # TODO(mert): remove this
-        self.group_size = 1
         
         self._states: list[State] = []
         self._initial_states: list[State] = []


### PR DESCRIPTION
## Summary
- Removed the hardcoded `self.group_size = 1` override in `PUCTSampler.__init__`
- Fixes #4